### PR TITLE
fix(adam): fix since options in LogcatRequest

### DIFF
--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/LogcatE2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/LogcatE2ETest.kt
@@ -16,31 +16,137 @@
 
 package com.malinskiy.adam.integration
 
+import com.malinskiy.adam.request.logcat.ChanneledLogcatRequest
 import com.malinskiy.adam.request.logcat.SyncLogcatRequest
 import com.malinskiy.adam.rule.AdbDeviceRule
 import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.*
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+// These regex comes from https://cs.android.com/android/platform/superproject/+/master:development/tools/bugreport/src/com/android/bugreport/logcat/LogcatParser.java
+private val BUFFER_BEGIN_RE = Pattern.compile("--------- beginning of (.*)")
+private val LOG_LINE_RE = Pattern.compile(
+    "((?:(\\d\\d\\d\\d)-)?(\\d\\d)-(\\d\\d)\\s+(\\d\\d):(\\d\\d):(\\d\\d)\\.(\\d\\d\\d)\\s+(\\d+)\\s+(\\d+)\\s+(.)\\s+)(.*?):\\s(.*)",
+    Pattern.MULTILINE
+)
+private val sinceFormatter = DateTimeFormatter.ofPattern("MM-dd HH:mm:ss.SSS")
+    .withZone(ZoneId.systemDefault())
 
 class LogcatE2ETest {
     @Rule
     @JvmField
     val adb = AdbDeviceRule()
-    val client = adb.adb
 
     @Rule
     @JvmField
     val timeout = CoroutinesTimeout.seconds(60)
 
-    private val instant = Instant.parse("2022-07-02T07:41:07Z")
-
     @Test
     fun testSyncRequest() {
         runBlocking {
-            val content = client.execute(SyncLogcatRequest(since = instant))
-            println(content)
+            val nowInstant = Instant.now()
+            val content = adb.adb.execute(SyncLogcatRequest(since = nowInstant, modes = listOf()), adb.deviceSerial)
+                .split("\n")
+                .mapNotNull { LogLine.of(it) }
+                .filterIsInstance<LogLine.Log>()
+
+            // Check if only logs after a given time are included
+            assertThat(content.any { it.instant.isBefore(nowInstant) }, equalTo(false))
+        }
+    }
+
+    @Test
+    fun testChanneledRequest() {
+        runBlocking {
+            val nowInstant = Instant.now()
+            val content = mutableSetOf<LogLine.Log>()
+            val channel = adb.adb.execute(ChanneledLogcatRequest(since = nowInstant, modes = listOf()), this, adb.deviceSerial)
+            // Receive logcat for max 5 seconds
+            for (i in 1..5) {
+                content += channel.receive()
+                    .split("\n")
+                    .mapNotNull { LogLine.of(it) }
+                    .filterIsInstance<LogLine.Log>()
+
+                delay(100)
+            }
+            channel.cancel()
+            assertThat(content.any { it.instant.isBefore(nowInstant) }, equalTo(false))
+        }
+    }
+
+    @Suppress("HasPlatformType", "MemberVisibilityCanBePrivate")
+    sealed class LogLine(val matcher: Matcher) {
+        class BufferLine(rawText: String) : LogLine(BUFFER_BEGIN_RE.matcher(rawText).also { it.find() }) {
+            val bufferBegin = matcher.group(1)
+
+            override fun toString() = "[BufferLine] $bufferBegin"
+        }
+
+        class Log(rawText: String) : LogLine(LOG_LINE_RE.matcher(rawText).also { it.find() }) {
+            val date = Calendar.getInstance().apply {
+                set(Calendar.MONTH, matcher.group(3).toInt())
+                set(Calendar.DAY_OF_MONTH, matcher.group(4).toInt())
+                set(Calendar.HOUR_OF_DAY, matcher.group(5).toInt())
+                set(Calendar.MINUTE, matcher.group(6).toInt())
+                set(Calendar.SECOND, matcher.group(7).toInt())
+                set(Calendar.MILLISECOND, matcher.group(8).toInt())
+            }
+
+            val pid = matcher.group(9)
+            val tid = matcher.group(10)
+            val level = matcher.group(11)[0]
+            val tag = matcher.group(12)
+            val text = matcher.group(13)
+
+            val instant get() = date.toInstant()
+
+
+            override fun toString() = "[LogLine] ${sinceFormatter.format(date.toInstant())} $pid $tid $level $tag: $text"
+
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as Log
+
+                if (date != other.date) return false
+                if (pid != other.pid) return false
+                if (tid != other.tid) return false
+                if (level != other.level) return false
+                if (tag != other.tag) return false
+                if (text != other.text) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                var result = date?.hashCode() ?: 0
+                result = 31 * result + (pid?.hashCode() ?: 0)
+                result = 31 * result + (tid?.hashCode() ?: 0)
+                result = 31 * result + level.hashCode()
+                result = 31 * result + (tag?.hashCode() ?: 0)
+                result = 31 * result + (text?.hashCode() ?: 0)
+                return result
+            }
+        }
+
+        companion object {
+            fun of(rawText: String): LogLine? = when {
+                BUFFER_BEGIN_RE.matcher(rawText).matches() -> BufferLine(rawText)
+                LOG_LINE_RE.matcher(rawText).matches() -> Log(rawText)
+                else -> null
+            }
         }
     }
 }

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/LogcatE2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/LogcatE2ETest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.integration
+
+import com.malinskiy.adam.request.logcat.SyncLogcatRequest
+import com.malinskiy.adam.rule.AdbDeviceRule
+import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import java.time.Instant
+
+class LogcatE2ETest {
+    @Rule
+    @JvmField
+    val adb = AdbDeviceRule()
+    val client = adb.adb
+
+    @Rule
+    @JvmField
+    val timeout = CoroutinesTimeout.seconds(60)
+
+    private val instant = Instant.parse("2022-07-02T07:41:07Z")
+
+    @Test
+    fun testSyncRequest() {
+        runBlocking {
+            val content = client.execute(SyncLogcatRequest(since = instant))
+            println(content)
+        }
+    }
+}

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/logcat/ChanneledLogcatRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/logcat/ChanneledLogcatRequest.kt
@@ -18,6 +18,11 @@ package com.malinskiy.adam.request.logcat
 
 import com.malinskiy.adam.request.shell.v1.ChanneledShellCommandRequest
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val sinceFormatter = DateTimeFormatter.ofPattern("MM-dd HH:mm:ss.SSS")
+    .withZone(ZoneId.systemDefault())
 
 class ChanneledLogcatRequest(
     since: Instant? = null,
@@ -28,11 +33,9 @@ class ChanneledLogcatRequest(
     filters: List<LogcatFilterSpec> = emptyList()
 ) : ChanneledShellCommandRequest(
     cmd = "logcat" +
-            "${
-                since?.let {
-                    " -T ${since.toEpochMilli()}.0"
-                } ?: ""
-            }" +
+            (since?.let {
+                " -T '${sinceFormatter.format(since)}'"
+            } ?: "") +
             " ${modes.joinToString(separator = " ") { "-v $it" }}" +
             if (buffers.isNotEmpty()) {
                 " ${buffers.joinToString(separator = " ") { "-b $it" }}"

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/logcat/SyncLogcatRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/logcat/SyncLogcatRequest.kt
@@ -19,6 +19,11 @@ package com.malinskiy.adam.request.logcat
 import com.malinskiy.adam.request.shell.v1.ShellCommandResult
 import com.malinskiy.adam.request.shell.v1.SyncShellCommandRequest
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val sinceFormatter = DateTimeFormatter.ofPattern("MM-dd HH:mm:ss.SSS")
+    .withZone(ZoneId.systemDefault())
 
 class SyncLogcatRequest(
     since: Instant? = null,
@@ -31,7 +36,7 @@ class SyncLogcatRequest(
     cmd = "logcat" +
             " -d" +
             (since?.let {
-                " -t ${since.toEpochMilli()}.0"
+                " -t '${sinceFormatter.format(since)}'"
             } ?: "") +
             " ${modes.joinToString(separator = " ") { "-v $it" }}" +
             " ${buffers.joinToString(separator = " ") { "-b $it" }}" +

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/logcat/AsyncLogcatRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/logcat/AsyncLogcatRequestTest.kt
@@ -53,10 +53,11 @@ class AsyncLogcatRequestTest {
 
     @Test
     fun testSinceContinuous() {
-        val cmd = ChanneledLogcatRequest(since = Instant.ofEpochMilli(10)).serialize()
+        val instant = Instant.parse("2022-07-02T07:41:07Z")
+        val cmd = ChanneledLogcatRequest(since = instant).serialize()
 
         assertThat(String(cmd, Const.DEFAULT_TRANSPORT_ENCODING))
-            .isEqualTo("001Cshell:logcat -T 10.0 -v long")
+            .isEqualTo("002Cshell:logcat -T '07-02 16:41:07.000' -v long")
     }
 
     @Test

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/logcat/SyncLogcatRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/logcat/SyncLogcatRequestTest.kt
@@ -25,14 +25,16 @@ import java.time.Instant
 class SyncLogcatRequestTest {
     @Test
     fun testSinceNonBlocking() {
+        val instant = Instant.parse("2022-07-02T07:41:07Z")
+
         val cmd = SyncLogcatRequest(
-            since = Instant.ofEpochMilli(10),
+            since = instant,
             filters = listOf(LogcatFilterSpec("TAG", LogcatVerbosityLevel.E))
         ).serialize()
 
         val actual = String(cmd, Const.DEFAULT_TRANSPORT_ENCODING)
         assertThat(actual)
-            .isEqualTo("0039shell:logcat -d -t 10.0 -v long -b default TAG:E;echo x$?")
+            .isEqualTo("0049shell:logcat -d -t '07-02 16:41:07.000' -v long -b default TAG:E;echo x$?")
     }
 
     @Test


### PR DESCRIPTION
(this pr is draft status while tasks are completed)

As describe in https://developer.android.com/studio/command-line/logcat#options, -t option accepts time string instead seconds.

This PR change contains using time string (MM-dd HH:mm:ss.SSS, ex, '01-26 20:52:41.820') instead time string. also add E2E Test to validate this feature

* [x] Change SyncLogcatRequest / ChanneledLogcatRequest
* [x] Changes exists unit test
* [ ] Write E2E Test